### PR TITLE
chg: remove ``bcRead.getHistoricalGlobalBalance(add, block)``

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@com-chain/jsc3l",
-  "version": "2.0.1-rc.16",
+  "version": "2.0.1-rc.17",
   "description": "JavaScript Com-Chain Communication Library",
   "main": "build/index.js",
   "scripts": {

--- a/src/bcRead.ts
+++ b/src/bcRead.ts
@@ -143,15 +143,6 @@ export default abstract class BcReadAbstract {
   // Get Global infos: Tax destinary Account
   getTaxAccount () { return this.read(this.contracts[0], '0x4f2eabe0') }
 
-  // Get Historical infos infos: Global balance
-  async getHistoricalGlobalBalance (walletAddress, blockNb) {
-    const data = await this.read(
-      this.contracts[0], '0x70a08231', [
-        getNakedAddress(walletAddress)
-      ], blockNb)
-    return decodeData('number/100', data)
-  }
-
   async getVersion () {
     const data = await this.read(this.contracts[0], '0x54fd4d50')
     return decodeData('string', data as string)
@@ -161,19 +152,19 @@ export default abstract class BcReadAbstract {
   // //////////////////////////////////////////////////////////////////////////
   // Generic read function
 
-  async getAmount (address, walletAddress) {
+  async getAmount (address, walletAddress, blockNb) {
     const data = await this.read(
       this.contracts[0], address, [
         getNakedAddress(walletAddress)
-      ])
+      ], blockNb)
     return decodeData('number/100', data)
   }
 
-  async getAccInfo (address, walletAddress) {
+  async getAccInfo (address, walletAddress, blockNb) {
     const data = await this.read(
       this.contracts[0], address, [
         getNakedAddress(walletAddress)
-      ])
+      ], blockNb)
     return decodeData('number', data)
   }
 
@@ -257,8 +248,8 @@ const fnHashes = [
 fnHashes.forEach(({ fn, hashes }) => {
   for (const fnName in hashes) {
     const fnHash = hashes[fnName]
-    BcReadAbstract.prototype[fnName] = function (walletAddress) {
-      return this[fn](fnHash, walletAddress)
+    BcReadAbstract.prototype[fnName] = function (walletAddress, blockNb) {
+      return this[fn](fnHash, walletAddress, blockNb)
     }
   }
 })


### PR DESCRIPTION
Was removed in favor of new second argument to all ``bcRead.get*(add, block)``

This basically makes all `bcRead` function able to query any point in history by providing a second argument.

By default, it matches the previous behavior: without a `blockNb` it will show "pending" status.
